### PR TITLE
Correct tab spacing and add host IP if server_name is empty

### DIFF
--- a/src/hpilo_exporter/exporter.py
+++ b/src/hpilo_exporter/exporter.py
@@ -88,14 +88,14 @@ class RequestHandler(BaseHTTPRequestHandler):
                 product_name = ilo.get_product_name()
             except:
                 product_name = "Unknown HP Server"
-                
+
             try:
                 server_name = ilo.get_server_name()
                 if server_name == "":
                     server_name = ilo_host
             except:
                 server_name = ilo_host
-      
+
             # get health
 	          embedded_health = ilo.get_embedded_health()
             health_at_glance = embedded_health['health_at_a_glance']

--- a/src/hpilo_exporter/exporter.py
+++ b/src/hpilo_exporter/exporter.py
@@ -85,15 +85,17 @@ class RequestHandler(BaseHTTPRequestHandler):
 
             # get product and server name
             try:
-        	product_name = ilo.get_product_name()
-    	    except:
-    		product_name = "Unknown HP Server"
-    		
-    	    try:
-        	server_name = ilo.get_server_name()
-    	    except:
-    		server_name = ""
-	    
+                product_name = ilo.get_product_name()
+            except:
+                product_name = "Unknown HP Server"
+        
+            try:
+                server_name = ilo.get_server_name()
+                if server_name == "":
+                    server_name = ilo_host
+            except:
+                server_name = ilo_host
+      
             # get health at glance
             health_at_glance = ilo.get_embedded_health()['health_at_a_glance']
             

--- a/src/hpilo_exporter/exporter.py
+++ b/src/hpilo_exporter/exporter.py
@@ -97,7 +97,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 server_name = ilo_host
 
             # get health
-	          embedded_health = ilo.get_embedded_health()
+            embedded_health = ilo.get_embedded_health()
             health_at_glance = embedded_health['health_at_a_glance']
             
             if health_at_glance is not None:


### PR DESCRIPTION
I found some tab spacing in the file, and I wanted to add the ILO IP if the server_name wasn't set.  